### PR TITLE
reflect lib enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,19 @@ data class SensitiveData(val creditCardNumber: String, val socialSecurityNumber:
 
 Mr. Clean manages the implementation of the `toString` for you.
 
+In debug builds, by default, Mr. Clean will utilize reflection to generate the toString on the fly.
+You can disable this behavior by adding this to your build.gradle
+
+```groovy
+mrclean {
+    useReflectInDebug = false
+}
+```
+
+By disabling reflection, you'll enable the annotation processor that generates code for you.
+
 ```kotlin
-// in a debuggable build
+// in a debuggable build with reflect disabled
 inline fun SensitiveData.sanitizedToString(condition: Boolean): String =
         "SensitiveData(creditCardNumber = $creditCardNumber, socialSecurityNumber = $socialSecurityNumber)"
 

--- a/mr-clean-plugin/src/main/java/com/trello/mrclean/plugin/GenerateRootFunctions.kt
+++ b/mr-clean-plugin/src/main/java/com/trello/mrclean/plugin/GenerateRootFunctions.kt
@@ -13,14 +13,17 @@ open class GenerateRootFunctions : DefaultTask() {
   @get:Input
   var packageName: String? = null
 
+  @get:Input
+  var useReflection: Boolean? = null
+
   @Suppress("unused") // Invoked by Gradle.
   @TaskAction
   fun brewJava() {
-    brewJava(outputDir!!, packageName!!)
+    brewJava(outputDir!!, packageName!!, useReflection!!)
   }
 }
 
-fun brewJava(outputDir: File, packageName: String) {
+fun brewJava(outputDir: File, packageName: String, useReflection: Boolean) {
   val compiler = RootFunctionGenerator()
-  compiler.createRootFunction(packageName).writeTo(outputDir)
+  compiler.createRootFunction(packageName, useReflection).writeTo(outputDir)
 }

--- a/mr-clean-plugin/src/main/java/com/trello/mrclean/plugin/MrCleanExtension.kt
+++ b/mr-clean-plugin/src/main/java/com/trello/mrclean/plugin/MrCleanExtension.kt
@@ -1,0 +1,5 @@
+package com.trello.mrclean.plugin
+
+open class MrCleanExtension {
+  var useReflectInDebug : Boolean = true
+}

--- a/mr-clean-plugin/src/main/java/com/trello/mrclean/plugin/RootFunctionGenerator.kt
+++ b/mr-clean-plugin/src/main/java/com/trello/mrclean/plugin/RootFunctionGenerator.kt
@@ -5,16 +5,27 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 
 class RootFunctionGenerator {
-  fun createRootFunction(packageName: String): FileSpec {
+  fun createRootFunction(packageName: String, useReflection: Boolean): FileSpec {
     val rootFunction = FunSpec.builder("sanitizedToString")
         .addModifiers(KModifier.INTERNAL)
         .receiver(Any::class)
         .returns(String::class)
         .apply {
-          addStatement("return error(%S)", "No function generated! Make sure to annotate with @Sanitize")
+          if (useReflection) {
+            addStatement("return reflectedToString()")
+          }
+          else {
+            addStatement("return error(%S)", "No function generated! Make sure to annotate with @Sanitize")
+          }
         }
         .build()
     return FileSpec.builder(packageName, "RootSanitizeFunction")
+        .apply {
+          // Switch to using %M with `MemberName` when updated to kotlinpoet 1.3
+          if (useReflection) {
+            addImport("com.trello.mrclean.reflect", "reflectedToString")
+          }
+        }
         .addFunction(rootFunction)
         .addComment("This is the root function that generated functions will overload")
         .build()

--- a/mr-clean-plugin/src/test/java/com/trello/mrclean/plugin/RootFunctionGeneratorTest.kt
+++ b/mr-clean-plugin/src/test/java/com/trello/mrclean/plugin/RootFunctionGeneratorTest.kt
@@ -10,7 +10,7 @@ class RootFunctionGeneratorTest {
   fun createRootFunction() {
     val generator = RootFunctionGenerator()
     val output = StringBuilder()
-    generator.createRootFunction("com.example").writeTo(output)
+    generator.createRootFunction("com.example", false).writeTo(output)
 
     val expectedOutput = """
       |// This is the root function that generated functions will overload

--- a/mr-clean-plugin/src/test/java/com/trello/mrclean/plugin/RootFunctionGeneratorTest.kt
+++ b/mr-clean-plugin/src/test/java/com/trello/mrclean/plugin/RootFunctionGeneratorTest.kt
@@ -7,7 +7,7 @@ import org.junit.Assert.*
 class RootFunctionGeneratorTest {
 
   @Test
-  fun createRootFunction() {
+  fun createRootFunctionWithoutReflection() {
     val generator = RootFunctionGenerator()
     val output = StringBuilder()
     generator.createRootFunction("com.example", false).writeTo(output)
@@ -21,6 +21,26 @@ class RootFunctionGeneratorTest {
 
       |internal fun Any.sanitizedToString(): String =
       |        error("No function generated! Make sure to annotate with @Sanitize")
+      |
+    """.trimMargin()
+    assertEquals(expectedOutput, output.toString())
+  }
+
+  @Test
+  fun createRootFunctionWithReflection() {
+    val generator = RootFunctionGenerator()
+    val output = StringBuilder()
+    generator.createRootFunction("com.example", true).writeTo(output)
+
+    val expectedOutput = """
+      |// This is the root function that generated functions will overload
+      |package com.example
+
+      |import com.trello.mrclean.reflect.reflectedToString
+      |import kotlin.Any
+      |import kotlin.String
+
+      |internal fun Any.sanitizedToString(): String = reflectedToString()
       |
     """.trimMargin()
     assertEquals(expectedOutput, output.toString())

--- a/mr-clean-reflect/src/main/java/com/trello/mrclean/reflect/Sanitizer.kt
+++ b/mr-clean-reflect/src/main/java/com/trello/mrclean/reflect/Sanitizer.kt
@@ -3,12 +3,12 @@ package com.trello.mrclean.reflect
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.javaGetter
 
-inline fun <reified T: Any> T.sanitizedToString(): String {
+inline fun <reified T: Any> T.reflectedToString(): String {
   val instance = this
   val sanitizedString = instance::class.memberProperties
       .joinToString {
         "${it.name} = ${it.javaGetter?.invoke(instance)}"
       }
-  return "{ $sanitizedString }"
+  return "${instance::class.simpleName}( $sanitizedString )"
 }
 

--- a/mr-clean-reflect/src/test/java/com/trello/mrclean/reflect/ReflectTest.kt
+++ b/mr-clean-reflect/src/test/java/com/trello/mrclean/reflect/ReflectTest.kt
@@ -14,44 +14,44 @@ class ReflectTest {
 
   @Test
   fun testReflectOneStringParam() {
-    assertEquals("{ stringParam = Meow }", OneStringParam("Meow").sanitizedToString())
+    assertEquals("OneStringParam( stringParam = Meow )", OneStringParam("Meow").reflectedToString())
   }
 
   @Test
   fun testReflectOneIntParam() {
-    assertEquals("{ intParam = 1 }", OneIntParam(1).sanitizedToString())
+    assertEquals("OneIntParam( intParam = 1 )", OneIntParam(1).reflectedToString())
   }
 
   @Test
   fun testReflectOneBooleanParam() {
-    assertEquals("{ booleanParam = false }",
-        OneBooleanParam(false).sanitizedToString())
+    assertEquals("OneBooleanParam( booleanParam = false )",
+        OneBooleanParam(false).reflectedToString())
   }
 
   @Test
   fun testReflectTwoPrimitiveParam() {
-    assertEquals("{ intParam = 2, stringParam = Meow }",
-        TwoPrimitiveParams("Meow", 2).sanitizedToString())
+    assertEquals("TwoPrimitiveParams( intParam = 2, stringParam = Meow )",
+        TwoPrimitiveParams("Meow", 2).reflectedToString())
   }
 
   @Test
   fun testReflectTwoComplexParam() {
-    assertEquals("{ oneIntParam = OneIntParam(intParam=1), oneStringParam = OneStringParam(stringParam=Meow) }",
-        TwoComplexParams(OneStringParam("Meow"), OneIntParam(1)).sanitizedToString())
+    assertEquals("TwoComplexParams( oneIntParam = OneIntParam(intParam=1), oneStringParam = OneStringParam(stringParam=Meow) )",
+        TwoComplexParams(OneStringParam("Meow"), OneIntParam(1)).reflectedToString())
   }
 
   @Test
   fun testReflectThreeComplexParams() {
-    assertEquals("{ oneBooleanParam = OneBooleanParam(booleanParam=false), oneIntParam = OneIntParam(intParam=1), oneStringParam = OneStringParam(stringParam=Meow) }",
-        ThreeComplexParams(OneStringParam("Meow"), OneIntParam(1), OneBooleanParam(false)).sanitizedToString())
+    assertEquals("ThreeComplexParams( oneBooleanParam = OneBooleanParam(booleanParam=false), oneIntParam = OneIntParam(intParam=1), oneStringParam = OneStringParam(stringParam=Meow) )",
+        ThreeComplexParams(OneStringParam("Meow"), OneIntParam(1), OneBooleanParam(false)).reflectedToString())
   }
 
   @Test
   fun testReflectNestedComplexParams() {
-    assertEquals("{ threeComplexParams1 = ThreeComplexParams(oneStringParam=OneStringParam(stringParam=Meow), oneIntParam=OneIntParam(intParam=1), oneBooleanParam=OneBooleanParam(booleanParam=true)), threeComplexParams2 = ThreeComplexParams(oneStringParam=OneStringParam(stringParam=bark), oneIntParam=OneIntParam(intParam=2), oneBooleanParam=OneBooleanParam(booleanParam=false)) }",
+    assertEquals("NestedComplexParams( threeComplexParams1 = ThreeComplexParams(oneStringParam=OneStringParam(stringParam=Meow), oneIntParam=OneIntParam(intParam=1), oneBooleanParam=OneBooleanParam(booleanParam=true)), threeComplexParams2 = ThreeComplexParams(oneStringParam=OneStringParam(stringParam=bark), oneIntParam=OneIntParam(intParam=2), oneBooleanParam=OneBooleanParam(booleanParam=false)) )",
         NestedComplexParams(
             ThreeComplexParams(OneStringParam("Meow"), OneIntParam(1), OneBooleanParam(true)),
             ThreeComplexParams(OneStringParam("bark"), OneIntParam(2), OneBooleanParam(false))
-        ).sanitizedToString())
+        ).reflectedToString())
   }
 }


### PR DESCRIPTION
Enables the reflect lib.


Also fixes two issues found when doing this: 

1. callsite was messy with everything named `sanitizedToString`. Rename the reflected version to be `reflectedToString`
2. Update the toString rendering to include class names.