### PR TITLE
Fix kapt incremental

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,11 +22,7 @@ buildscript {
         'kotlinx': [
             'metadataJvm':"org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0"
         ],
-        'kotlinpoet': 'com.squareup:kotlinpoet:1.4.0',
-        'packageIdentifier': [
-            'annotations': "com.trello.identifier:package-identifier-annotations:0.0.2",
-            'plugin': "com.trello.identifier:package-identifier-plugin:0.0.2"
-        ]
+        'kotlinpoet': 'com.squareup:kotlinpoet:1.4.0'
     ]
 
     repositories {

--- a/mr-clean-plugin/build.gradle
+++ b/mr-clean-plugin/build.gradle
@@ -9,8 +9,6 @@ dependencies {
     implementation deps.kotlin.stdlib
     implementation deps.kotlinpoet
 
-    implementation deps.packageIdentifier.plugin
-
     testImplementation deps.junit
 }
 

--- a/mr-clean-plugin/src/main/java/com/trello/mrclean/plugin/MrCleanPlugin.kt
+++ b/mr-clean-plugin/src/main/java/com/trello/mrclean/plugin/MrCleanPlugin.kt
@@ -74,9 +74,13 @@ class MrCleanPlugin : Plugin<Project> {
     variants.all { variant ->
       val once = AtomicBoolean()
 
+      // apply APT options for use in MrCleanProcessor
+      val packageName = getPackageName(variant)
+      variant.javaCompileOptions.annotationProcessorOptions.arguments["mrclean.packagename"] = packageName
+      variant.javaCompileOptions.annotationProcessorOptions.arguments["mrclean.debug"] = variant.buildType.isDebuggable.toString()
+
       variant.outputs.all { output ->
         if (once.compareAndSet(false, true)) {
-          val packageName = getPackageName(variant)
           val taskName = "generate${variant.name.capitalize()}RootSanitizeFunction"
           val outputDir = project.buildDir.resolve("generated/source/mrclean/${variant.name}")
           val task = project.tasks

--- a/mr-clean-plugin/src/main/java/com/trello/mrclean/plugin/MrCleanPlugin.kt
+++ b/mr-clean-plugin/src/main/java/com/trello/mrclean/plugin/MrCleanPlugin.kt
@@ -27,7 +27,6 @@ class MrCleanPlugin : Plugin<Project> {
 
   override fun apply(project: Project) {
     project.plugins.apply("kotlin-kapt")
-    project.plugins.apply("com.trello.identifier")
 
     project.allprojects.forEach {
       it.repositories.maven { mavenRepo -> mavenRepo.setUrl("https://kotlin.bintray.com/kotlinx/") }

--- a/mr-clean-processor/build.gradle
+++ b/mr-clean-processor/build.gradle
@@ -15,8 +15,6 @@ dependencies {
 
     compile deps.kotlinpoet
 
-    compileOnly deps.packageIdentifier.annotations
-
     testCompile deps.junit
 }
 

--- a/mr-clean-processor/src/main/java/com/trello/mrclean/MrCleanProcessor.kt
+++ b/mr-clean-processor/src/main/java/com/trello/mrclean/MrCleanProcessor.kt
@@ -18,7 +18,6 @@ package com.trello.mrclean
 
 import com.google.auto.service.AutoService
 import com.squareup.kotlinpoet.FileSpec
-import com.trello.identifier.annotation.PackageId
 import com.trello.mrclean.annotations.Sanitize
 import kotlinx.metadata.impl.extensions.MetadataExtensions
 import kotlinx.metadata.jvm.KotlinClassMetadata
@@ -50,11 +49,9 @@ class MrCleanProcessor : AbstractProcessor() {
   private var packageName: String? = null
 
   private val sanitize = Sanitize::class.java
-  private val packageIdentifier = PackageId::class.java
 
   override fun getSupportedAnnotationTypes(): MutableSet<String> = mutableSetOf(
-      sanitize.canonicalName,
-      packageIdentifier.canonicalName
+      sanitize.canonicalName
   )
 
   override fun getSupportedSourceVersion(): SourceVersion = SourceVersion.latest()

--- a/mr-clean-processor/src/main/java/com/trello/mrclean/MrCleanProcessor.kt
+++ b/mr-clean-processor/src/main/java/com/trello/mrclean/MrCleanProcessor.kt
@@ -17,14 +17,7 @@
 package com.trello.mrclean
 
 import com.google.auto.service.AutoService
-import com.squareup.kotlinpoet.AnnotationSpec
-import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
-import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.KModifier
-import com.squareup.kotlinpoet.asClassName
-import com.squareup.kotlinpoet.asTypeName
 import com.trello.identifier.annotation.PackageId
 import com.trello.mrclean.annotations.Sanitize
 import kotlinx.metadata.impl.extensions.MetadataExtensions
@@ -39,7 +32,6 @@ import javax.annotation.processing.ProcessingEnvironment
 import javax.annotation.processing.Processor
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.SourceVersion
-import javax.lang.model.element.Element
 import javax.lang.model.element.TypeElement
 import javax.lang.model.util.Elements
 import javax.lang.model.util.Types
@@ -54,6 +46,8 @@ class MrCleanProcessor : AbstractProcessor() {
   private lateinit var typeUtils: Types
   private lateinit var filer: Filer
   private var generatedDir: File? = null
+  private var isDebug: Boolean = false
+  private var packageName: String? = null
 
   private val sanitize = Sanitize::class.java
   private val packageIdentifier = PackageId::class.java
@@ -65,6 +59,12 @@ class MrCleanProcessor : AbstractProcessor() {
 
   override fun getSupportedSourceVersion(): SourceVersion = SourceVersion.latest()
 
+  override fun getSupportedOptions() = mutableSetOf(
+    OPTION_KAPT_GENERATED,
+    OPTION_DEBUG,
+    OPTION_PACKAGE_NAME
+  )
+
   override fun init(processingEnv: ProcessingEnvironment) {
     super.init(processingEnv)
     messager = processingEnv.messager
@@ -72,13 +72,12 @@ class MrCleanProcessor : AbstractProcessor() {
     typeUtils = processingEnv.typeUtils
     filer = processingEnv.filer
     generatedDir = processingEnv.options[OPTION_KAPT_GENERATED]?.let(::File)
+    // load properties applied by MrCleanPlugin
+    isDebug = processingEnv.options[OPTION_DEBUG] == "true"
+    packageName = processingEnv.options[OPTION_PACKAGE_NAME]!!
   }
 
   override fun process(annotations: MutableSet<out TypeElement>, roundEnv: RoundEnvironment): Boolean {
-    val packageIdentifierClass = roundEnv.getElementsAnnotatedWith(packageIdentifier).firstOrNull()
-        ?: return true
-    val isDebug = packageIdentifierClass.getAnnotation(packageIdentifier).isDebug
-    val targetPackage = elementUtils.getPackageOf(packageIdentifierClass).qualifiedName.toString()
     val funs = roundEnv.getElementsAnnotatedWith(sanitize)
         .map {
           val classHeader = it.getClassHeader()!!
@@ -97,7 +96,7 @@ class MrCleanProcessor : AbstractProcessor() {
 
     funs.map { (element, funSpec) ->
       val enclosingElementName = element.enclosingElement.simpleName.toString().capitalize()
-      FileSpec.builder(targetPackage, "SanitizationFor$enclosingElementName${element.simpleName}")
+      FileSpec.builder(packageName!!, "SanitizationFor$enclosingElementName${element.simpleName}")
           .apply {
             if (isDebug) addComment("Debug") else addComment("Release")
           }
@@ -115,6 +114,16 @@ class MrCleanProcessor : AbstractProcessor() {
      * Name of the processor option containing the path to the Kotlin generated src dir.
      */
     private const val OPTION_KAPT_GENERATED = "kapt.kotlin.generated"
+
+    /**
+     * Compiler options that get added by MrCleanPlugin
+     * mrclean.debug - whether the variant's build type is debuggable
+     * mrclean.packagename - the root package name for the project
+     *
+     * Changes here must be reflected in MrCleanPlugin.kt
+     */
+    private const val OPTION_DEBUG = "mrclean.debug"
+    private const val OPTION_PACKAGE_NAME = "mrclean.packagename"
 
     init {
       // https://youtrack.jetbrains.net/issue/KT-24881


### PR DESCRIPTION
The package-identifier code was breaking kapt-incremental. Since the package class did not change between runs, the function call looking for things annotated with `PackageId` returned null, which bailed out of the entire annotation processor. Now we don't use the package-identifier plugin at all, and just pass the required values through to the processor as annotation processor options.