### PR TITLE
Revert kapt-incremental fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,11 @@ buildscript {
         'kotlinx': [
             'metadataJvm':"org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0"
         ],
-        'kotlinpoet': 'com.squareup:kotlinpoet:1.4.0'
+        'kotlinpoet': 'com.squareup:kotlinpoet:1.4.0',
+        'packageIdentifier': [
+            'annotations': "com.trello.identifier:package-identifier-annotations:0.0.2",
+            'plugin': "com.trello.identifier:package-identifier-plugin:0.0.2"
+        ]
     ]
 
     repositories {

--- a/mr-clean-plugin/build.gradle
+++ b/mr-clean-plugin/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     implementation deps.kotlin.stdlib
     implementation deps.kotlinpoet
 
+    implementation deps.packageIdentifier.plugin
+
     testImplementation deps.junit
 }
 

--- a/mr-clean-plugin/src/main/java/com/trello/mrclean/plugin/MrCleanPlugin.kt
+++ b/mr-clean-plugin/src/main/java/com/trello/mrclean/plugin/MrCleanPlugin.kt
@@ -27,6 +27,7 @@ class MrCleanPlugin : Plugin<Project> {
 
   override fun apply(project: Project) {
     project.plugins.apply("kotlin-kapt")
+    project.plugins.apply("com.trello.identifier")
 
     project.allprojects.forEach {
       it.repositories.maven { mavenRepo -> mavenRepo.setUrl("https://kotlin.bintray.com/kotlinx/") }

--- a/mr-clean-plugin/src/main/java/com/trello/mrclean/plugin/MrCleanPlugin.kt
+++ b/mr-clean-plugin/src/main/java/com/trello/mrclean/plugin/MrCleanPlugin.kt
@@ -74,13 +74,9 @@ class MrCleanPlugin : Plugin<Project> {
     variants.all { variant ->
       val once = AtomicBoolean()
 
-      // apply APT options for use in MrCleanProcessor
-      val packageName = getPackageName(variant)
-      variant.javaCompileOptions.annotationProcessorOptions.arguments["mrclean.packagename"] = packageName
-      variant.javaCompileOptions.annotationProcessorOptions.arguments["mrclean.debug"] = variant.buildType.isDebuggable.toString()
-
       variant.outputs.all { output ->
         if (once.compareAndSet(false, true)) {
+          val packageName = getPackageName(variant)
           val taskName = "generate${variant.name.capitalize()}RootSanitizeFunction"
           val outputDir = project.buildDir.resolve("generated/source/mrclean/${variant.name}")
           val task = project.tasks

--- a/mr-clean-processor/build.gradle
+++ b/mr-clean-processor/build.gradle
@@ -15,6 +15,8 @@ dependencies {
 
     compile deps.kotlinpoet
 
+    compileOnly deps.packageIdentifier.annotations
+
     testCompile deps.junit
 }
 

--- a/mr-clean-processor/src/main/java/com/trello/mrclean/MrCleanProcessor.kt
+++ b/mr-clean-processor/src/main/java/com/trello/mrclean/MrCleanProcessor.kt
@@ -18,6 +18,7 @@ package com.trello.mrclean
 
 import com.google.auto.service.AutoService
 import com.squareup.kotlinpoet.FileSpec
+import com.trello.identifier.annotation.PackageId
 import com.trello.mrclean.annotations.Sanitize
 import kotlinx.metadata.impl.extensions.MetadataExtensions
 import kotlinx.metadata.jvm.KotlinClassMetadata
@@ -49,9 +50,11 @@ class MrCleanProcessor : AbstractProcessor() {
   private var packageName: String? = null
 
   private val sanitize = Sanitize::class.java
+  private val packageIdentifier = PackageId::class.java
 
   override fun getSupportedAnnotationTypes(): MutableSet<String> = mutableSetOf(
-      sanitize.canonicalName
+      sanitize.canonicalName,
+      packageIdentifier.canonicalName
   )
 
   override fun getSupportedSourceVersion(): SourceVersion = SourceVersion.latest()


### PR DESCRIPTION
Reverting the fix to get a 1.0.2-SNAPSHOT that works published - then we can re-apply the fix and bump to 1.0.3