### PR TITLE
Update to SNAPSHOT version, update RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,7 +11,7 @@ Releasing
  8. Update the `gradle.properties` to the next SNAPSHOT version.
  9. `git commit -am "Prepare next development version."`
  10. `git push && git push --tags`
- 11. Update the sample app to the release version and send a PR.
+ 11. Open a PR.
 
 
 Prerequisites

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.trello.mrclean
-VERSION_NAME=1.2.0
+VERSION_NAME=1.2.1-SNAPSHOT
 
 POM_DESCRIPTION=Gradle plugin for generating release worthy toStrings
 


### PR DESCRIPTION
We accidentally pushed a non-SNAPSHOT version, this fixes that mistake. Also updated RELEASING.md to remove reference to the non-existent sample app.