### PR TITLE
Release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.2.1
+* Updates Kotlin to 1.8.10
+* Updates Android Gradle Plugin to 7.4.1
+* Updates ben-manes versions plugin to 0.45.0
+* Updated to use new Gradle variant API internally
+
 # 1.2.0
 * Updates Kotlin to 1.7.10
 * Updates ben-manes versions plugin to 0.42.0

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ buildscript {
     google()
    }
   dependencies {
-    classpath 'com.trello.mrclean:mr-clean-plugin:1.2.0'
+    classpath 'com.trello.mrclean:mr-clean-plugin:1.2.1'
   }
 }
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.trello.mrclean
-VERSION_NAME=1.2.1
+VERSION_NAME=1.2.2-SNAPSHOT
 
 POM_DESCRIPTION=Gradle plugin for generating release worthy toStrings
 POM_INCEPTION_YEAR=2018

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.trello.mrclean
-VERSION_NAME=1.2.1-SNAPSHOT
+VERSION_NAME=1.2.1
 
 POM_DESCRIPTION=Gradle plugin for generating release worthy toStrings
 POM_INCEPTION_YEAR=2018


### PR DESCRIPTION
1.2.1 is [published](https://oss.sonatype.org/index.html#nexus-search;quick~com.trello.mrclean), this PR merges in the 1.2.1 release and prepares for 1.2.2