### PR TITLE
update: gradle wrapper-validation-action v3 -> v4

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Validate Gradle Wrapper
-      uses: gradle/wrapper-validation-action@v3
+      uses: gradle/actions/wrapper-validation@v4
 
     - name: Configure JDK
       uses: actions/setup-java@v4
@@ -35,11 +35,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Configure JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'zulu'
           java-version: 17
 
       - name: Upload Artifacts


### PR DESCRIPTION
Something caused the previous PR to fail on `master` but not on the PR branch:

```
Error: Multiple errors returned
Error: Error 0: connect ETIMEDOUT 104.16.72.101:443
Error: connect ETIMEDOUT 104.[16](https://github.com/trello-archive/mr-clean/actions/runs/15282522465/job/42984861858#step:3:18).72.101:443
    at createConnectionError (node:net:1652:14)
    at Timeout.internalConnectMultipleTimeout (node:net:[17](https://github.com/trello-archive/mr-clean/actions/runs/15282522465/job/42984861858#step:3:19)11:38)
    at listOnTimeout (node:internal/timers:583:11)
    at process.processTimers (node:internal/timers:519:7)
Error: Error 1: connect ENETUNREACH 2606:4700::6810:4965:443 - Local (:::0)
Error: connect ENETUNREACH 2606:4700::6810:4965:443 - Local (:::0)
    at internalConnectMultiple (node:net:1[18](https://github.com/trello-archive/mr-clean/actions/runs/15282522465/job/42984861858#step:3:20)6:16)
    at Timeout.internalConnectMultipleTimeout (node:net:1716:5)
    at listOnTimeout (node:internal/timers:583:11)
    at process.processTimers (node:internal/timers:5[19](https://github.com/trello-archive/mr-clean/actions/runs/15282522465/job/42984861858#step:3:21):7)
Error: Error 2: connect ETIMEDOUT 104.16.73.101:443
Error: connect ETIMEDOUT 104.16.73.101:443
    at createConnectionError (node:net:1652:14)
    at Timeout.internalConnectMultipleTimeout (node:net:1711:38)
    at listOnTimeout (node:internal/timers:583:11)
    at process.processTimers (node:internal/timers:519:7)
Error: Error 3: connect ENETUNREACH 2606:4700::6810:4865:443 - Local (:::0)
Error: connect ENETUNREACH [26](https://github.com/trello-archive/mr-clean/actions/runs/15282522465/job/42984861858#step:3:28)06:4700::6810:4865:443 - Local (:::0)
    at internalConnectMultiple (node:net:1186:16)
    at Timeout.internalConnectMultipleTimeout (node:net:1716:5)
    at listOnTimeout (node:internal/timers:583:11)
    at process.processTimers (node:internal/timers:519:7)
```
Appears to be related to https://github.com/gradle/actions/issues/631 which from the comments looks like this may work, may not. But also problematic we weren't using the correct namespace after updating.

I also updated deps in the publish step, which I didn't do previously.